### PR TITLE
Change softGlueRegisterInterruptRoutine 

### DIFF
--- a/softGlueApp/src/MCSAsub.c
+++ b/softGlueApp/src/MCSAsub.c
@@ -211,7 +211,7 @@ int MCSPrepare(const char *componentName, epicsUInt32 risingMask, int fifoSize) 
 	 * with the specified risingMask.  This also tells softGlue to not execute any output links that might
 	 * also have been programmed to execute in response to this value of risingMask.
 	 */
-	softGlueRegisterInterruptRoutine(risingMask, 0, MCSRoutine, (void *)&myISRData);
+	softGlueZynqRegisterInterruptRoutine(risingMask, 0, MCSRoutine, (void *)&myISRData);
 
 	return(0);
 }

--- a/softGlueApp/src/devSGscaler16.c
+++ b/softGlueApp/src/devSGscaler16.c
@@ -172,7 +172,7 @@ STATIC int scalerISRSetup(int card)
 {	
 	Debug(5, "scalerISRSetup: Entry, card #%d\n", card);
 	if ((card+1) > scaler_total_cards) return(ERROR);
-	softGlueRegisterInterruptRoutine(0x80000000, 0, scalerISR, (void *)NULL);
+	softGlueZynqRegisterInterruptRoutine(0x80000000, 0, scalerISR, (void *)NULL);
 	Debug(5, "scalerISRSetup: Exit, card #%d\n", card);
 	return (OK);
 }

--- a/softGlueApp/src/drvZynq.c
+++ b/softGlueApp/src/drvZynq.c
@@ -473,7 +473,7 @@ int initZynqSingleRegisterPort(const char *portName, const char *componentName)
 	UIO_struct *pUIO = NULL;
 
 	pPvt = callocMustSucceed(1, sizeof(*pPvt), "drvZynqPvt");
-	driverTable[numDriverTables++] = pPvt;	/* save pointers for softGlueRegisterInterruptRoutine() */
+	driverTable[numDriverTables++] = pPvt;	/* save pointers for softGlueZynqRegisterInterruptRoutine() */
 	pPvt->portName = epicsStrDup(portName);
 
 	/* Set up address */
@@ -798,9 +798,9 @@ STATIC int numRegisteredIntRoutines=0;
  * example invocation:
  *      void callMe(softGlueIntRoutineData *IRData);
  *		myDataType myData;
- *      softGlueRegisterInterruptRoutine(0x1, 0x0, callMe, (void *)&myData);
+ *      softGlueZynqRegisterInterruptRoutine(0x1, 0x0, callMe, (void *)&myData);
  */
-int softGlueRegisterInterruptRoutine(epicsUInt32 risingMask, epicsUInt32 fallingMask,
+int softGlueZynqRegisterInterruptRoutine(epicsUInt32 risingMask, epicsUInt32 fallingMask,
 	void (*routine)(softGlueIntRoutineData *IRData), void *userPvt) {
 
 	if (numRegisteredIntRoutines >= MAXROUTINES-1) return(-1);
@@ -809,7 +809,7 @@ int softGlueRegisterInterruptRoutine(epicsUInt32 risingMask, epicsUInt32 falling
 	registeredIntRoutines[numRegisteredIntRoutines].routine = routine;
 	registeredIntRoutines[numRegisteredIntRoutines].IRData.userPvt = userPvt;
 
-	if (drvZynqDebug>5) printf("softGlueRegisterInterruptRoutine: #%d, risingMask=0x%x, fallingMask=0x%x",
+	if (drvZynqDebug>5) printf("softGlueZynqRegisterInterruptRoutine: #%d, risingMask=0x%x, fallingMask=0x%x",
 	  numRegisteredIntRoutines, risingMask, fallingMask);
 	numRegisteredIntRoutines++;
 	return(0);

--- a/softGlueApp/src/drvZynq.h
+++ b/softGlueApp/src/drvZynq.h
@@ -40,7 +40,7 @@ extern UIO_struct *UIO[MAX_UIO];
 
 int findUioAddr(const char *componentName, int map);
 
-int softGlueRegisterInterruptRoutine(epicsUInt32 risingMask, epicsUInt32 fallingMask,
+int softGlueZynqRegisterInterruptRoutine(epicsUInt32 risingMask, epicsUInt32 fallingMask,
 	void (*routine)(softGlueIntRoutineData *IRData), void *userPvt);
 
 epicsUInt32 *softGlueZCalcSpecifiedRegisterAddress(int type, int addr);

--- a/softGlueApp/src/pixelTrigger.c
+++ b/softGlueApp/src/pixelTrigger.c
@@ -98,7 +98,7 @@ int pixelTriggerPrepare(int AXI_Address, epicsUInt32 risingMask, int numX, int n
 	 * with the specified risingMask.  This also tells softGlue to not execute any output links that might
 	 * also have been programmed to execute in response to this value of risingMask.
 	 */
-	softGlueRegisterInterruptRoutine(risingMask, 0, pixelTriggerRoutine, (void *)&myISRData);
+	softGlueZynqRegisterInterruptRoutine(risingMask, 0, pixelTriggerRoutine, (void *)&myISRData);
 
 	return(0);
 }

--- a/softGlueApp/src/pixelTriggerAsub.c
+++ b/softGlueApp/src/pixelTriggerAsub.c
@@ -286,7 +286,7 @@ int pixelTriggerPrepare(const char *componentName, epicsUInt32 risingMask, int f
 	 * with the specified risingMask.  This also tells softGlue to not execute any output links that might
 	 * also have been programmed to execute in response to this value of risingMask.
 	 */
-	softGlueRegisterInterruptRoutine(risingMask, 0, pixelTriggerRoutine, (void *)&myISRData);
+	softGlueZynqRegisterInterruptRoutine(risingMask, 0, pixelTriggerRoutine, (void *)&myISRData);
 
 	return(0);
 }

--- a/softGlueApp/src/pixelTriggerDmaAsub.c
+++ b/softGlueApp/src/pixelTriggerDmaAsub.c
@@ -449,7 +449,7 @@ int pixelTriggerDmaPrepare(const char *componentName, epicsUInt32 risingMask, in
 	 * with the specified risingMask.  This also tells softGlue to not execute any output links that might
 	 * also have been programmed to execute in response to this value of risingMask.
 	 */
-	softGlueRegisterInterruptRoutine(risingMask, 0, pixelTriggerDmaRoutine, (void *)&myDmaISRData);
+	softGlueZynqRegisterInterruptRoutine(risingMask, 0, pixelTriggerDmaRoutine, (void *)&myDmaISRData);
 
 	return(0);
 }

--- a/softGlueApp/src/readSoftGlueCounter_ISR.c
+++ b/softGlueApp/src/readSoftGlueCounter_ISR.c
@@ -136,7 +136,7 @@ int readSoftGlueCounter_ISRPrepare(epicsUInt32 risingMask) {
 	 * output links that might have been programmed to execute in response to this interrupt.
 	 * The second arg is for fallingMask, which hasn't been implemented yet.
 	 */
-	softGlueRegisterInterruptRoutine(risingMask, 0, readSoftGlueCounterISR, (void *)&rcISRData);
+	softGlueZynqRegisterInterruptRoutine(risingMask, 0, readSoftGlueCounterISR, (void *)&rcISRData);
 	return(0);
 }
 

--- a/softGlueApp/src/sampleCustomInterruptHandler.c
+++ b/softGlueApp/src/sampleCustomInterruptHandler.c
@@ -85,7 +85,7 @@ int sampleCustomInterruptPrepare(epicsUInt32 risingMask, epicsUInt32 fallingMask
 	 * tells softGlue to not execute any output links that might also have been programmed to
 	 * execute in response to this interrupt.
 	 */
-	softGlueRegisterInterruptRoutine(risingMask, fallingMask, sampleCustomInterruptRoutine,
+	softGlueZynqRegisterInterruptRoutine(risingMask, fallingMask, sampleCustomInterruptRoutine,
 		(void *)&myISRData);
 
 	/* prepare example data for sampleCustomInterruptRoutine() */


### PR DESCRIPTION
Change softGlueRegisterInterruptRoutine to softGlueZynqRegisterInterruptRoutine to avoid conflict with softGlue.