### PR TITLE
Add epics-modules ci-scripts for Travis CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".ci"]
+	path = .ci
+	url = https://github.com/epics-base/ci-scripts.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,130 @@
+# .travis.xml for use with EPICS Base ci-scripts
+# (see: https://github.com/epics-base/ci-scripts)
+
+language: cpp
+compiler: gcc
+dist: xenial
+
+cache:
+  directories:
+  - $HOME/.cache
+
+env:
+  global:
+    - SETUP_PATH=.ci
+    - MODULES="sncseq asyn std"
+    - SNCSEQ=R2-2-8
+    - ASYN=R4-38
+    - STD=R3-6-1
+
+addons:
+  apt:
+    packages:
+    # for all EPICS builds
+    - libreadline6-dev
+    - libncurses5-dev
+    - perl
+    # for clang compiler
+    - clang
+    # for mingw builds (32bit and 64bit)
+    - g++-mingw-w64-i686
+    - g++-mingw-w64-x86-64
+    # for RTEMS cross builds
+    - qemu-system-x86
+  homebrew:
+    packages:
+    # for all EPICS builds
+    - bash
+    # for the sequencer
+    - re2c
+    update: true
+
+install:
+  - ./.ci/travis/prepare.sh
+
+script:
+  - ./.ci/travis/build.sh
+
+# If you need to do more during install and build,
+# add a local directory to your module and do e.g.
+#  - ./.ci-local/travis/install-extras.sh
+
+# Define build jobs
+
+# Well-known variables to use
+# SET      source setup file
+# EXTRA    content will be added to make command line
+# STATIC   set to YES for static build (default: NO)
+# TEST     set to NO to skip running the tests (default: YES)
+# VV       set to make build scripts verbose (default: unset)
+
+# Usually from setup files, but may be specified or overridden
+#  on a job line
+# MODULES  list of dependency modules
+# BASE     branch or release tag name of the EPICS Base to use
+# <MODULE> branch or release tag for a specific module
+# ...      see README for setup file syntax description
+
+jobs:
+  include:
+
+# Default gcc and clang, static build
+
+  - env: BASE=7.0
+
+  - env: BASE=7.0
+    compiler: clang
+
+  - env: BASE=7.0 STATIC=YES
+
+# Trusty: compiler versions very close to RHEL 7
+
+  - env: BASE=7.0
+    dist: trusty
+
+# Cross-compilations to Windows using MinGW and WINE
+    
+  - env: BASE=7.0 WINE=32 TEST=NO STATIC=YES
+    compiler: mingw
+
+  - env: BASE=7.0 WINE=64 TEST=NO STATIC=NO
+    compiler: mingw
+
+# MacOS build
+
+  - env: BASE=7.0
+    os: osx
+    compiler: clang
+
+# Cross-compilation to RTEMS
+
+  - env: BASE=7.0 RTEMS=4.10
+
+  - env: BASE=7.0 RTEMS=4.9
+
+# Older Base releases
+
+  - env: BASE=R3.15.7
+
+  - env: BASE=R3.15.7 STATIC=YES
+
+# 3.14.12.2 build fails on newer distributions and doesn't know tapfiles target
+  - env: BASE=R3.14.12.2 TEST=NO
+    dist: trusty
+
+  - env: BASE=R3.14.12.2 STATIC=YES TEST=NO
+    dist: trusty
+
+  - env: BASE=R3.14.12.8
+
+  - env: BASE=R3.14.12.8 STATIC=YES
+
+# Other gcc versions (added as an extra package)
+
+  - env: BASE=7.0
+    compiler: gcc-6
+    addons: { apt: { packages: ["g++-6"], sources: ["ubuntu-toolchain-r-test"] } }
+
+  - env: BASE=7.0
+    compiler: gcc-7
+    addons: { apt: { packages: ["g++-7"], sources: ["ubuntu-toolchain-r-test"] } }


### PR DESCRIPTION
EPICS R3.14 builds currently fail due to missing MSI (current issue on ci-scripts: https://github.com/epics-base/ci-scripts/issues/20)