### PR TITLE
Make myISRData static

### DIFF
--- a/softGlueApp/src/MCSAsub.c
+++ b/softGlueApp/src/MCSAsub.c
@@ -58,7 +58,7 @@ typedef struct {
 	int currChannel;
 	int maxChannels;
 } myISRDataStruct;
-myISRDataStruct myISRData;
+static myISRDataStruct myISRData;
 
 static long MCS_init(aSubRecord *pasub) {
 	epicsUInt32 *a = (epicsUInt32 *)pasub->a;

--- a/softGlueApp/src/pixelTrigger.c
+++ b/softGlueApp/src/pixelTrigger.c
@@ -26,7 +26,7 @@ typedef struct {
 	int **pixels;
 	int numX, numY, numScalers;
 } myISRDataStruct;
-myISRDataStruct myISRData;
+static myISRDataStruct myISRData;
 
 /* When an interrupt matching conditions specified by pixelTriggerPrepare() occurs,
  * we'll get called with the bitmask that generated the interrupt, and the bit that went low or high.

--- a/softGlueApp/src/pixelTriggerAsub.c
+++ b/softGlueApp/src/pixelTriggerAsub.c
@@ -66,7 +66,7 @@ typedef struct {
 	int fifoSize;
 	int cleared;
 } myISRDataStruct;
-myISRDataStruct myISRData;
+static myISRDataStruct myISRData;
 
 static long pixelTrigger_init(aSubRecord *pasub) {
 	epicsUInt32 *a = (epicsUInt32 *)pasub->a;

--- a/softGlueApp/src/pixelTriggerDmaAsub.c
+++ b/softGlueApp/src/pixelTriggerDmaAsub.c
@@ -81,7 +81,7 @@ typedef struct {
 	epicsUInt32 *numX, *numY, *numScalers;
 	int cleared, *acqMode, allocatedElements, *debug;
 } myISRDataStruct;
-myISRDataStruct myDmaISRData;
+static myISRDataStruct myDmaISRData;
 
 static long pixelTriggerDma_init(aSubRecord *pasub) {
 	epicsUInt32 *a = (epicsUInt32 *)pasub->a;

--- a/softGlueApp/src/sampleCustomInterruptHandler.c
+++ b/softGlueApp/src/sampleCustomInterruptHandler.c
@@ -24,7 +24,7 @@ typedef struct {
 	int numValues;
 	int thisValue;
 } myISRDataStruct;
-myISRDataStruct myISRData;
+static myISRDataStruct myISRData;
 
 #define MAX_VALUES 1000
 static int sampleCustomInterruptValues[MAX_VALUES];


### PR DESCRIPTION
softGlueZynq fails to compile with gcc 11.2.0 with the following errors:
********************
/usr/bin/g++ -o libsoftGlueZynq.so  -shared -fPIC -Wl,-hlibsoftGlueZynq.so -L/corvette/home/epics/devel/softGlueZynq-2-0-4/lib/linux-x86_64-ub18 -L/corvette/home/epics/devel/asyn-4-43/lib/linux-x86_64-ub18 -L/corvette/home/epics/devel/seq-2-2-5/lib/linux-x86_64-ub18 -L/corvette/usr/local/epics-devel/base-7.0.7/lib/linux-x86_64-ub18 -Wl,-rpath,/corvette/home/epics/devel/softGlueZynq-2-0-4/lib/linux-x86_64-ub18 -Wl,-rpath,/corvette/home/epics/devel/asyn-4-43/lib/linux-x86_64-ub18 -Wl,-rpath,/corvette/home/epics/devel/seq-2-2-5/lib/linux-x86_64-ub18 -Wl,-rpath,/corvette/usr/local/epics-devel/base-7.0.7/lib/linux-x86_64-ub18          -rdynamic -m64          drvZynq.o devAsynSoftGlue.o devA32Zed.o sampleCustomInterruptHandler.o pixelTriggerAsub.o scalerAsub.o pixelTriggerDmaAsub.o histScalerDmaAsub.o MCSAsub.o clockConfigAsub.o readSoftGlueCounter_ISR.o devSGscaler16.o   -lasyn -lseq -lpv -ldbRecStd -ldbCore -lca -lCom   -lpthread   -lreadline -lm -lrt -ldl -lgcc

/usr/bin/ld: pixelTriggerAsub.o:/corvette/home/epics/devel/softGlueZynq-2-0-4/softGlueApp/src/O.linux-x86_64-ub18/../pixelTriggerAsub.c:69: multiple definition of `myISRData'; sampleCustomInterruptHandler.o:/corvette/home/epics/devel/softGlueZynq-2-0-4/softGlueApp/src/O.linux-x86_64-ub18/../sampleCustomInterruptHandler.c:27: first defined here

/usr/bin/ld: MCSAsub.o:/corvette/home/epics/devel/softGlueZynq-2-0-4/softGlueApp/src/O.linux-x86_64-ub18/../MCSAsub.c:61: multiple definition of `myISRData'; sampleCustomInterruptHandler.o:/corvette/home/epics/devel/softGlueZynq-2-0-4/softGlueApp/src/O.linux-x86_64-ub18/../sampleCustomInterruptHandler.c:27: first defined here
collect2: error: ld returned 1 exit status
********************

I think this is probably because the definitions of myISRData at the beginning of each file should be static, not global?
